### PR TITLE
Sync tomcat user creation with thredds/tomcat-docker change

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,16 @@ set -e
 
 if [ "$1" = 'start-tomcat.sh' ] || [ "$1" = 'catalina.sh' ]; then
 
+    USER_ID=${TOMCAT_USER_ID:-1000}
+    GROUP_ID=${TOMCAT_GROUP_ID:-1000}
+
+    ###
+    # Tomcat user
+    ###
+    groupadd -r tomcat -g ${GROUP_ID} && \
+    useradd -u ${USER_ID} -g tomcat -d ${CATALINA_HOME} -s /sbin/nologin \
+        -c "Tomcat user" tomcat
+
     chown -R tomcat:tomcat ${CATALINA_HOME} && chmod 400 ${CATALINA_HOME}/conf/*
     sync
 


### PR DESCRIPTION
The Docker hub autobuild `guygriffiths/ncwms` image fails atm, because this change was merged into the `unidata/tomcat-docker:8` image.

