### PR TITLE
fix the null alias bug

### DIFF
--- a/src/main/java/uk/ac/rdg/resc/edal/ncwms/NcwmsCatalogue.java
+++ b/src/main/java/uk/ac/rdg/resc/edal/ncwms/NcwmsCatalogue.java
@@ -312,7 +312,7 @@ public class NcwmsCatalogue extends DataCatalogue implements WmsCatalogue {
     private NcwmsDynamicService getDynamicServiceFromLayerName(String layerName) {
         NcwmsDynamicService dynamicService = null;
         for (NcwmsDynamicService testDynamicService : ((NcwmsConfig) config).getDynamicServices()) {
-            if (layerName.startsWith(testDynamicService.getAlias())) {
+            if (testDynamicService.getAlias()!=null && layerName.startsWith(testDynamicService.getAlias())) {
                 dynamicService = testDynamicService;
             }
         }


### PR DESCRIPTION
In the administrator interface, people can save a dynamic service with no value for alias (I am sure that should be a bug too). 
That will make all the other dynamic services inaccessible. All the requests will return "the layer XXX is not found". 
This fix will solve that problem.