### PR TITLE
Bump the log4j dependency version to v2.21.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.17.0</version>
+            <version>2.21.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.gwt</groupId>


### PR DESCRIPTION
The log4J dependencies in this application was/is to version 2.17.0 which still has the critical log4shell vulnerability that was patched almost 2 years ago. See https://logging.apache.org/log4j/2.x/index.html#important-security-vulnerability-cve-2021-44832 

This PR updates both to v2.21.1, which is the current stable and supported version of log4j.

It would supersede https://github.com/Reading-eScience-Centre/ncwms/pull/87